### PR TITLE
Fix FTBS with glibc 2.27

### DIFF
--- a/gui/phasewheel.c
+++ b/gui/phasewheel.c
@@ -812,7 +812,7 @@ static bool cb_set_gain (RobWidget* handle, void *data) {
 		queue_draw(ui->m2);
 	}
 #ifdef __USE_GNU
-	const float thresh = pow10f(.05 * (MIN_CUTOFF - val));
+	const float thresh = exp10f(.05 * (MIN_CUTOFF - val));
 #else
 	const float thresh = powf(10, .05 * (MIN_CUTOFF - val));
 #endif


### PR DESCRIPTION
glibc 2.27 has removed pow10 functions
https://sourceware.org/git/?p=glibc.git;a=commit;h=5a80d39d0d2587e9bd8e72f19e92eeb2a66fbe9e